### PR TITLE
Fix code scanning alert no. 1: Cross-site scripting

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,6 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>core</artifactId>
     <dependencies>
+    <dependency>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-text</artifactId>
+    <version>1.12.0</version>
+    </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/core/src/main/java/com/soft/processors/assembler/controllers/AssemblerController.java
+++ b/core/src/main/java/com/soft/processors/assembler/controllers/AssemblerController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * AssemblerController is a Spring Boot REST controller responsible for handling requests related to
@@ -63,7 +64,8 @@ public class AssemblerController {
           throws IOException, InvalidFileException {
     checkNotEmpty(file);
     var fileContent = new String(file.getBytes(), StandardCharsets.UTF_8);
-    return ResponseEntity.ok(fileContent);
+    var sanitizedContent = StringEscapeUtils.escapeHtml4(fileContent);
+    return ResponseEntity.ok(sanitizedContent);
   }
 
   /**


### PR DESCRIPTION
Fixes [https://github.com/KalinIvanov-l/lcp-assembly/security/code-scanning/1](https://github.com/KalinIvanov-l/lcp-assembly/security/code-scanning/1)

To fix the cross-site scripting vulnerability, we need to ensure that the file content is properly sanitized before being included in the HTTP response. One effective way to do this is to encode the content to ensure that any potentially malicious scripts are rendered harmless. In this case, we can use the `StringEscapeUtils` class from the Apache Commons Text library to escape the HTML content.

1. Add the Apache Commons Text library to the project dependencies if it's not already included.
2. Import the `StringEscapeUtils` class in the `AssemblerController` class.
3. Use `StringEscapeUtils.escapeHtml4` to sanitize the `fileContent` before returning it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
